### PR TITLE
Add adapter for converting LORIS username/password to HTTP Bearer token

### DIFF
--- a/datalad/downloaders/configs/loris.cfg
+++ b/datalad/downloaders/configs/loris.cfg
@@ -1,11 +1,10 @@
 [provider:loris-demo]
 url_re = https?://demo.loris.ca/api/v0.0.2/.*
 credential = loris-demo
-authentication_type = bearer_token
-bearer_token_failure_re = "User not authenticated"}$
-
+authentication_type = loris-token
+loris-token_failure_re = "User not authenticated"}$
 
 [credential:loris-demo]
-url = https://demo.loris.ca
-type = token
+url = https://demo.loris.ca/api/v0.0.2/login
+type = loris-token
 

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -274,13 +274,13 @@ class CompositeCredential(Credential):
                 self._CREDENTIAL_ADAPTERS[idx:],
                 self._credentials[idx + 1:]):
             fields = c()
-            next_fields = adapter(**fields)
+            next_fields = adapter(self, **fields)
             next_c.set(**next_fields)
 
         return self._credentials[-1]()
 
 
-def _nda_adapter(user=None, password=None):
+def _nda_adapter(composite, user=None, password=None):
     from datalad.support.third.nda_aws_token_generator import NDATokenGenerator
     gen = NDATokenGenerator()
     token = gen.generate_token(user, password)
@@ -302,13 +302,14 @@ class NDA_S3(CompositeCredential):
     _CREDENTIAL_ADAPTERS = (_nda_adapter,)
 
 
-def _loris_adapter(user=None, password=None, **kwargs):
+def _loris_adapter(composite, user=None, password=None, **kwargs):
     from datalad.support.third.loris_token_generator import LORISTokenGenerator
 
-    gen = LORISTokenGenerator(url=_loris_adapter.url)
+    gen = LORISTokenGenerator(url=composite.url)
     token = gen.generate_token(user, password)
 
     return dict(token=token)
+
 
 class LORIS_Token(CompositeCredential):
     _CREDENTIAL_CLASSES = (UserPassword, Token)
@@ -316,10 +317,6 @@ class LORIS_Token(CompositeCredential):
 
     def __init__(self, name, url=None, keyring=None):
         super(CompositeCredential, self).__init__(name, url, keyring)
-        # Hack to get the URL passed to _loris_adapter
-        _loris_adapter.url = url
-
-
 
 CREDENTIAL_TYPES = {
     'user_password': UserPassword,

--- a/datalad/downloaders/credentials.py
+++ b/datalad/downloaders/credentials.py
@@ -302,9 +302,29 @@ class NDA_S3(CompositeCredential):
     _CREDENTIAL_ADAPTERS = (_nda_adapter,)
 
 
+def _loris_adapter(user=None, password=None, **kwargs):
+    from datalad.support.third.loris_token_generator import LORISTokenGenerator
+
+    gen = LORISTokenGenerator(url=_loris_adapter.url)
+    token = gen.generate_token(user, password)
+
+    return dict(token=token)
+
+class LORIS_Token(CompositeCredential):
+    _CREDENTIAL_CLASSES = (UserPassword, Token)
+    _CREDENTIAL_ADAPTERS = (_loris_adapter,)
+
+    def __init__(self, name, url=None, keyring=None):
+        super(CompositeCredential, self).__init__(name, url, keyring)
+        # Hack to get the URL passed to _loris_adapter
+        _loris_adapter.url = url
+
+
+
 CREDENTIAL_TYPES = {
     'user_password': UserPassword,
     'aws-s3': AWS_S3,
     'nda-s3': NDA_S3,
     'token': Token,
+    'loris-token': LORIS_Token
 }

--- a/datalad/downloaders/providers.py
+++ b/datalad/downloaders/providers.py
@@ -43,6 +43,7 @@ AUTHENTICATION_TYPES = {
     'bearer_token': HTTPBearerTokenAuthenticator,
     'aws-s3': S3Authenticator,  # TODO: check if having '-' is kosher
     'nda-s3': S3Authenticator,
+    'loris-token': HTTPBearerTokenAuthenticator,
     'xnat': NotImplementedAuthenticator,
     'none': NoneAuthenticator,
 }

--- a/datalad/support/third/loris_token_generator.py
+++ b/datalad/support/third/loris_token_generator.py
@@ -1,0 +1,23 @@
+import sys
+import json
+
+if sys.version_info[0] == 2:
+    import urllib2 as urllib_request
+else:
+    from urllib import request as urllib_request
+
+class LORISTokenGenerator(object):
+    def __init__(self, url=None):
+        assert(url is not None)
+        self.url = url
+
+    def generate_token(self, user=None, password=None):
+        data = {'username': user, 'password' : password}
+        encoded_data = json.dumps(data).encode('utf-8')
+
+        request = urllib_request.Request(self.url, encoded_data)
+
+        response = urllib_request.urlopen(request)
+        data = json.load(response)
+        return data["token"]
+


### PR DESCRIPTION
Added an adapter which converts usernames and passwords to tokens via the LORIS API.

This is not thread-safe, since it uses a hack of adding url as a property to the _loris_adapter function in order to pass the URL between the composite credential and the adapter.